### PR TITLE
proxy: DNS-резолв через туннель и UDP ASSOCIATE для SOCKS5-прокси

### DIFF
--- a/aivpn-client/Cargo.toml
+++ b/aivpn-client/Cargo.toml
@@ -10,6 +10,12 @@ repository.workspace = true
 name = "aivpn-client"
 path = "src/main.rs"
 
+[profile.release]
+panic = "unwind"
+
+[env]
+RUST_BACKTRACE = "1"
+
 [features]
 default = []
 # Production secure mode: disables built-in bootstrap fallback
@@ -53,7 +59,7 @@ portable-atomic = "1"
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
 
 # Userspace TCP/IP stack for proxy mode (--proxy-listen)
-smoltcp = { version = "0.11", default-features = false, features = ["alloc", "medium-ip", "proto-ipv4", "socket-tcp"] }
+smoltcp = { version = "0.11", default-features = false, features = ["socket-dns", "alloc", "medium-ip", "proto-ipv4", "proto-ipv6", "socket-tcp", "socket-udp"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2"

--- a/aivpn-client/src/client.rs
+++ b/aivpn-client/src/client.rs
@@ -113,6 +113,7 @@ pub struct AivpnClient {
     _send_buf: Vec<u8>,
     _recv_buf: Vec<u8>,
     proxy_rx_queue: Option<Arc<Mutex<VecDeque<Vec<u8>>>>>,
+    proxy_wake_tx: Option<std::sync::mpsc::Sender<()>>,
     // Recording tracking
     active_recording_session: Option<[u8; 16]>,
     keepalive_interval: Duration,
@@ -158,6 +159,7 @@ impl AivpnClient {
             _send_buf: Vec::with_capacity(MAX_PACKET_SIZE),
             _recv_buf: Vec::with_capacity(MAX_PACKET_SIZE),
             proxy_rx_queue: None,
+            proxy_wake_tx: None,
             active_recording_session: None,
             keepalive_interval: Duration::from_secs(DEFAULT_KEEPALIVE_SECS as u64),
         })
@@ -409,6 +411,7 @@ impl AivpnClient {
                 .await
                 .map_err(Error::Io)?;
             self.proxy_rx_queue = Some(Arc::clone(&handle.rx_queue));
+            self.proxy_wake_tx = Some(handle.wake_tx.clone());
         }
 
         // Take the TUN reader for the spawned task (skipped in proxy mode)
@@ -826,6 +829,9 @@ impl AivpnClient {
                 }
                 if let Some(q) = &self.proxy_rx_queue {
                     q.lock().unwrap().push_back(ip_payload.to_vec());
+                    if let Some(wtx) = &self.proxy_wake_tx {
+                        let _ = wtx.send(()); // входящий пакет → стек poll'ит мгновенно
+                    }
                 } else {
                     self.tunnel.write_packet_async(&ip_payload).await?;
                 }

--- a/aivpn-client/src/proxy/mod.rs
+++ b/aivpn-client/src/proxy/mod.rs
@@ -1,27 +1,42 @@
 pub mod device;
 pub mod socks5;
 
-use std::collections::VecDeque;
-use std::net::{Ipv4Addr, SocketAddr};
+use std::collections::{HashMap, VecDeque};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::atomic::{AtomicBool, AtomicU16, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use smoltcp::iface::{Config, Interface, SocketHandle, SocketSet};
 use smoltcp::socket::tcp::{Socket as TcpSocket, SocketBuffer as TcpSocketBuffer, State};
+use smoltcp::socket::udp::{
+    PacketBuffer as UdpPacketBuffer, PacketMetadata as UdpPacketMetadata, Socket as UdpSocket,
+};
 use smoltcp::time::Instant as SmolInstant;
-use smoltcp::wire::{HardwareAddress, IpAddress, IpCidr, IpEndpoint, Ipv4Address};
+use smoltcp::wire::{HardwareAddress, IpAddress, IpCidr, IpEndpoint, Ipv4Address, Ipv6Address};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::mpsc;
 use tracing::{debug, error, info, warn};
 
 use crate::proxy::device::VpnDevice;
-use crate::proxy::socks5::{Socks5Session, REP_GENERAL_FAILURE, REP_HOST_UNREACHABLE, REP_SUCCESS};
+use crate::proxy::socks5::{
+    build_udp_response, parse_udp_request, Socks5Command,
+    Socks5UdpTarget, Socks5Session, TargetAddr,
+    REP_GENERAL_FAILURE, REP_HOST_UNREACHABLE, REP_SUCCESS,
+};
 
-/// MTU matching WAN_SAFE_TUN_MTU in tunnel.rs
-const PROXY_MTU: usize = 1346;
+use smoltcp::socket::dns;
+use smoltcp::wire::DnsQueryType as DnsType;
+
+/// MTU: совпадает с WAN_SAFE_TUN_MTU в tunnel.rs
+const PROXY_MTU: usize = 1280;
 const TCP_BUF: usize = 65536;
+const UDP_PACKET_BUF: usize = 128;
+const UDP_PAYLOAD_BUF: usize = 65536;
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const UDP_ASSOCIATE_TIMEOUT: Duration = Duration::from_secs(10);
+const UDP_ASSOCIATE_IDLE_TIMEOUT: Duration = Duration::from_secs(300);
+const DNS_QUERY_TIMEOUT: Duration = Duration::from_secs(5);
 
 static SRC_PORT: AtomicU16 = AtomicU16::new(49152);
 
@@ -41,7 +56,6 @@ struct ManagedConn {
     inbound: Arc<Mutex<VecDeque<Vec<u8>>>>,
     outbound_tx: tokio::sync::mpsc::Sender<Vec<u8>>,
     close_flag: Arc<AtomicBool>,
-    /// Present until TCP handshake completes, then cleared.
     ready_tx: Option<std::sync::mpsc::SyncSender<bool>>,
 }
 
@@ -54,7 +68,53 @@ struct NewConn {
     ready_tx: std::sync::mpsc::SyncSender<bool>,
 }
 
-/// Start the smoltcp stack thread and SOCKS5 listener.
+struct ManagedUdpAssoc {
+    handle: SocketHandle,
+    relay_port: u16,
+    outbound_tx: mpsc::Sender<UdpRelayResponse>,
+    close_flag: Arc<AtomicBool>,
+    ready_tx: Option<std::sync::mpsc::SyncSender<bool>>,
+    last_seen: Instant,
+}
+
+struct NewUdpAssoc {
+    relay_port: u16,
+    outbound_tx: mpsc::Sender<UdpRelayResponse>,
+    close_flag: Arc<AtomicBool>,
+    ready_tx: std::sync::mpsc::SyncSender<bool>,
+}
+
+struct UdpPacketCommand {
+    relay_port: u16,
+    target: IpEndpoint,
+    payload: Vec<u8>,
+}
+
+struct UdpRelayResponse {
+    relay_port: u16,
+    remote: IpEndpoint,
+    payload: Vec<u8>,
+}
+
+struct DnsResolve {
+    name: String,
+    qtype: DnsType,                                  // A или Aaaa
+    reply: std::sync::mpsc::SyncSender<Option<IpAddr>>,
+}
+
+struct PendingDns {
+    handle: dns::QueryHandle,
+    reply: std::sync::mpsc::SyncSender<Option<IpAddr>>,
+    started: Instant,
+}
+
+enum UdpStackCommand {
+    CreateAssoc(NewUdpAssoc),
+    SendPacket(UdpPacketCommand),
+    Resolve(DnsResolve),                             // ← добавили
+}
+
+/// Запустить smoltcp-стек и SOCKS5-слушатель.
 pub async fn spawn_proxy(
     config: ProxyConfig,
     tun_to_udp_tx: mpsc::Sender<Vec<u8>>,
@@ -63,6 +123,7 @@ pub async fn spawn_proxy(
     let tx_queue: Arc<Mutex<VecDeque<Vec<u8>>>> = Arc::new(Mutex::new(VecDeque::new()));
 
     let (cmd_tx, cmd_rx) = std::sync::mpsc::channel::<NewConn>();
+    let (udp_cmd_tx, udp_cmd_rx) = std::sync::mpsc::channel::<UdpStackCommand>();
 
     let vpn_ip = config.vpn_ip;
     let gateway_ip = config.gateway_ip;
@@ -76,6 +137,7 @@ pub async fn spawn_proxy(
             tx_clone,
             tun_to_udp_tx,
             cmd_rx,
+            udp_cmd_rx,
             vpn_ip,
             gateway_ip,
             prefix_len,
@@ -85,13 +147,15 @@ pub async fn spawn_proxy(
     let listener = tokio::net::TcpListener::bind(config.listen_addr).await?;
     info!("SOCKS5 proxy listening on {}", config.listen_addr);
 
+    let proxy_ip = config.listen_addr.ip();
     tokio::spawn(async move {
         loop {
             match listener.accept().await {
                 Ok((stream, peer)) => {
                     debug!("Proxy: connection from {}", peer);
                     let tx = cmd_tx.clone();
-                    tokio::spawn(handle_socks5(stream, tx));
+                    let udp_tx = udp_cmd_tx.clone();
+                    tokio::spawn(handle_socks5(stream, tx, udp_tx, proxy_ip));
                 }
                 Err(e) => {
                     error!("Proxy accept error: {}", e);
@@ -119,11 +183,13 @@ fn alloc_src_port() -> u16 {
     p
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_stack(
     rx_queue: Arc<Mutex<VecDeque<Vec<u8>>>>,
     tx_queue: Arc<Mutex<VecDeque<Vec<u8>>>>,
     tun_to_udp_tx: mpsc::Sender<Vec<u8>>,
     cmd_rx: std::sync::mpsc::Receiver<NewConn>,
+    udp_cmd_rx: std::sync::mpsc::Receiver<UdpStackCommand>,
     vpn_ip: Ipv4Addr,
     gateway_ip: Ipv4Addr,
     prefix_len: u8,
@@ -144,10 +210,17 @@ fn run_stack(
         .add_default_ipv4_route(Ipv4Address::new(ga, gb, gc, gd));
 
     let mut sockets = SocketSet::new(vec![]);
-    let mut conns: Vec<ManagedConn> = Vec::new();
+    let mut tcp_conns: Vec<ManagedConn> = Vec::new();
+    let mut udp_assocs: HashMap<u16, ManagedUdpAssoc> = HashMap::new();
+
+    let dns_servers = [IpAddress::v4(1, 1, 1, 1)]; // TODO: получать адреса извне, важно: работает ток с одним адресом :(
+    // Vec даёт owned-слоты; find_free_query() сам делает push при нехватке.
+    let dns_socket = dns::Socket::new(&dns_servers, Vec::<Option<dns::DnsQuery>>::new());
+    let dns_handle = sockets.add(dns_socket);
+    let mut pending_dns: Vec<PendingDns> = Vec::new();
 
     loop {
-        // Accept new connection requests from the async SOCKS5 handlers
+        // Принимаем новые TCP CONNECT-запросы.
         loop {
             match cmd_rx.try_recv() {
                 Ok(nc) => {
@@ -160,7 +233,7 @@ fn run_stack(
                     match socket.connect(&mut cx, nc.target, nc.src_port) {
                         Ok(()) => {
                             let handle = sockets.add(socket);
-                            conns.push(ManagedConn {
+                            tcp_conns.push(ManagedConn {
                                 handle,
                                 inbound: nc.inbound,
                                 outbound_tx: nc.outbound_tx,
@@ -179,45 +252,202 @@ fn run_stack(
             }
         }
 
-        // Drive the network stack
+        // Принимаем команды UDP ASSOCIATE и пакеты на отправку.
+        loop {
+            match udp_cmd_rx.try_recv() {
+                Ok(UdpStackCommand::CreateAssoc(nc)) => {
+                    if udp_assocs.contains_key(&nc.relay_port) {
+                        let _ = nc.ready_tx.send(false);
+                        continue;
+                    }
+
+                    let rx_meta = vec![UdpPacketMetadata::EMPTY; UDP_PACKET_BUF];
+                    let tx_meta = vec![UdpPacketMetadata::EMPTY; UDP_PACKET_BUF];
+                    let rx_buf = UdpPacketBuffer::new(rx_meta, vec![0u8; UDP_PAYLOAD_BUF]);
+                    let tx_buf = UdpPacketBuffer::new(tx_meta, vec![0u8; UDP_PAYLOAD_BUF]);
+                    let mut socket = UdpSocket::new(rx_buf, tx_buf);
+
+                    if let Err(e) = socket.bind(nc.relay_port) {
+                        error!("smoltcp udp bind error on {}: {}", nc.relay_port, e);
+                        let _ = nc.ready_tx.send(false);
+                        continue;
+                    }
+
+                    let handle = sockets.add(socket);
+                    udp_assocs.insert(
+                        nc.relay_port,
+                        ManagedUdpAssoc {
+                            handle,
+                            relay_port: nc.relay_port,
+                            outbound_tx: nc.outbound_tx,
+                            close_flag: nc.close_flag,
+                            ready_tx: Some(nc.ready_tx),
+                            last_seen: Instant::now(),
+                        },
+                    );
+                }
+                Ok(UdpStackCommand::SendPacket(pkt)) => {
+                    if let Some(assoc) = udp_assocs.get_mut(&pkt.relay_port) {
+                        assoc.last_seen = Instant::now();
+                        let socket = sockets.get_mut::<UdpSocket>(assoc.handle);
+                        if let Err(e) = socket.send_slice(&pkt.payload, pkt.target) {
+                            warn!(
+                                "SOCKS5 UDP send failed on relay port {}: {}",
+                                pkt.relay_port, e
+                            );
+                        }
+                    }
+                }
+                Ok(UdpStackCommand::Resolve(r)) => {
+                    let dns_sock = sockets.get_mut::<dns::Socket>(dns_handle);
+                    let mut cx = iface.context();
+                    match dns_sock.start_query(&mut cx, &r.name, r.qtype) {
+                        Ok(handle) => pending_dns.push(PendingDns {
+                            handle,
+                            reply: r.reply,
+                            started: Instant::now(),
+                        }),
+                        Err(e) => {
+                            warn!("dns start_query '{}' failed: {}", r.name, e);
+                            let _ = r.reply.send(None);
+                        }
+                    }
+                }
+                Err(std::sync::mpsc::TryRecvError::Empty) => break,
+                Err(std::sync::mpsc::TryRecvError::Disconnected) => return,
+            }
+        }
+
         iface.poll(smoltcp_now(), &mut device, &mut sockets);
 
-        // Forward smoltcp TX packets to the VPN upload pipeline
+        // Отправляем в транспорт все IP-пакеты, которые smoltcp подготовил.
         {
-            let mut q = tx_queue.lock().unwrap();
+            let mut q = tx_queue.lock().unwrap_or_else(|e| e.into_inner());
             while let Some(pkt) = q.pop_front() {
-                if tun_to_udp_tx.blocking_send(pkt).is_err() {
-                    return;
+                match tun_to_udp_tx.try_send(pkt) {
+                    Ok(()) => {}
+                    Err(tokio::sync::mpsc::error::TrySendError::Full(pkt)) => {
+                        q.push_front(pkt);   // транспорт занят — вернём в очередь, попробуем в след. тик
+                        break;               // но НЕ морозим весь стек
+                    }
+                    Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => return,
                 }
             }
         }
+        // {
+        //     let mut q = tx_queue.lock().unwrap();
+        //     while let Some(pkt) = q.pop_front() {
+        //         if tun_to_udp_tx.blocking_send(pkt).is_err() {
+        //             return;
+        //         }
+        //     }
+        // }
 
-        // Service each active connection
-        let mut remove: Vec<usize> = Vec::new();
-        for (i, conn) in conns.iter_mut().enumerate() {
-            if service_conn(conn, &mut sockets) {
-                remove.push(i);
+        // Обслуживаем DNS-резолв через туннель.
+        if !pending_dns.is_empty() {
+            let dns_sock = sockets.get_mut::<dns::Socket>(dns_handle);
+            pending_dns.retain_mut(|p| match dns_sock.get_query_result(p.handle) {
+                Ok(addrs) => {
+                    let _ = p.reply.send(addrs.iter().next().copied().map(smol_ip_to_std));
+                    false
+                }
+                Err(dns::GetQueryResultError::Pending) => {
+                    if p.started.elapsed() > DNS_QUERY_TIMEOUT {
+                        dns_sock.cancel_query(p.handle); // освобождаем слот
+                        let _ = p.reply.send(None);
+                        false
+                    } else {
+                        true
+                    }
+                }
+                Err(dns::GetQueryResultError::Failed) => {
+                    let _ = p.reply.send(None);
+                    false
+                }
+            });
+        }
+
+        // Обслуживаем TCP-соединения.
+        let mut remove_tcp: Vec<usize> = Vec::new();
+        for (i, conn) in tcp_conns.iter_mut().enumerate() {
+            if service_tcp_conn(conn, &mut sockets) {
+                remove_tcp.push(i);
             }
         }
-        for i in remove.into_iter().rev() {
-            let conn = conns.remove(i);
+        for i in remove_tcp.into_iter().rev() {
+            let conn = tcp_conns.remove(i);
             sockets.remove(conn.handle);
+        }
+
+        // Обслуживаем UDP relay.
+        let mut remove_udp_ports: Vec<u16> = Vec::new();
+        for assoc in udp_assocs.values_mut() {
+            if service_udp_assoc(assoc, &mut sockets) {
+                remove_udp_ports.push(assoc.relay_port);
+            }
+        }
+        for relay_port in remove_udp_ports {
+            if let Some(assoc) = udp_assocs.remove(&relay_port) {
+                sockets.remove(assoc.handle);
+            }
         }
 
         std::thread::sleep(Duration::from_millis(1));
     }
 }
 
-/// Returns true when the connection should be removed from the active list.
-fn service_conn(conn: &mut ManagedConn, sockets: &mut SocketSet) -> bool {
+async fn resolve_via_tunnel(
+    cmd_tx: &std::sync::mpsc::Sender<UdpStackCommand>,
+    host: &str,
+    port: u16,
+    want_v6: bool,
+) -> std::io::Result<SocketAddr> {
+    let order: &[DnsType] = if want_v6 {
+        &[DnsType::Aaaa, DnsType::A]
+    } else {
+        &[DnsType::A]
+    };
+
+    for &qtype in order {
+        let (tx, rx) = std::sync::mpsc::sync_channel::<Option<IpAddr>>(1);
+        if cmd_tx
+            .send(UdpStackCommand::Resolve(DnsResolve {
+                name: host.to_string(),
+                qtype,
+                reply: tx,
+            }))
+            .is_err()
+        {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "stack thread gone",
+            ));
+        }
+        let ip = tokio::task::spawn_blocking(move || {
+            rx.recv_timeout(DNS_QUERY_TIMEOUT).ok().flatten()
+        })
+        .await
+        .unwrap_or(None);
+
+        if let Some(ip) = ip {
+            return Ok(SocketAddr::new(ip, port));
+        }
+    }
+
+    Err(std::io::Error::new(
+        std::io::ErrorKind::NotFound,
+        format!("DNS via tunnel: no result for {host}:{port}"),
+    ))
+}
+
+/// Возвращает `true`, когда TCP-соединение нужно удалить.
+fn service_tcp_conn(conn: &mut ManagedConn, sockets: &mut SocketSet) -> bool {
     let socket = sockets.get_mut::<TcpSocket>(conn.handle);
 
-    // While TCP handshake is pending, check socket state
     if let Some(ready_tx) = conn.ready_tx.take() {
         match socket.state() {
             State::Established => {
                 let _ = ready_tx.send(true);
-                // Fall through to service any data that arrived in parallel
             }
             State::Closed | State::TimeWait | State::CloseWait => {
                 let _ = ready_tx.send(false);
@@ -230,20 +460,17 @@ fn service_conn(conn: &mut ManagedConn, sockets: &mut SocketSet) -> bool {
         }
     }
 
-    // SOCKS5 client disconnected
     if conn.close_flag.load(Ordering::Relaxed) {
         socket.abort();
         return true;
     }
 
-    // Write queued data from SOCKS5 client → smoltcp TCP socket
     if socket.may_send() {
         let mut q = conn.inbound.lock().unwrap();
         while !q.is_empty() && socket.can_send() {
             let chunk = q.pop_front().unwrap();
             match socket.send_slice(&chunk) {
                 Ok(n) if n < chunk.len() => {
-                    // Partial write — put remainder back at the front
                     q.push_front(chunk[n..].to_vec());
                     break;
                 }
@@ -253,16 +480,41 @@ fn service_conn(conn: &mut ManagedConn, sockets: &mut SocketSet) -> bool {
         }
     }
 
-    // Read data from smoltcp TCP socket → SOCKS5 client
+    // if socket.can_recv() {
+    //     let mut tmp = vec![0u8; 4096];
+    //     if let Ok(n) = socket.recv_slice(&mut tmp) {
+    //         if n > 0 {
+    //             tmp.truncate(n);
+    //             if conn.outbound_tx.try_send(tmp).is_err() {
+    //                 socket.abort();
+    //                 return true;
+    //             }
+    //         }
+    //     }
+    // }
     if socket.can_recv() {
-        let mut tmp = vec![0u8; 4096];
-        if let Ok(n) = socket.recv_slice(&mut tmp) {
-            if n > 0 {
-                tmp.truncate(n);
-                if conn.outbound_tx.try_send(tmp).is_err() {
+        // Сливаем всё, что smoltcp набуферил, но только под наличие места в канале.
+        // Нет места → не читаем (TCP-окно придержит сервер). НЕ abort.
+        loop {
+            let permit = match conn.outbound_tx.try_reserve() {
+                Ok(p) => p,
+                Err(tokio::sync::mpsc::error::TrySendError::Full(())) => break,
+                Err(tokio::sync::mpsc::error::TrySendError::Closed(())) => {
                     socket.abort();
                     return true;
                 }
+            };
+            if !socket.can_recv() {
+                break;
+            }
+            let mut tmp = vec![0u8; 16384];
+            match socket.recv_slice(&mut tmp) {
+                Ok(0) => break,
+                Ok(n) => {
+                    tmp.truncate(n);
+                    permit.send(tmp);
+                }
+                Err(_) => break,
             }
         }
     }
@@ -273,11 +525,87 @@ fn service_conn(conn: &mut ManagedConn, sockets: &mut SocketSet) -> bool {
     )
 }
 
-async fn handle_socks5(stream: tokio::net::TcpStream, cmd_tx: std::sync::mpsc::Sender<NewConn>) {
+/// Возвращает `true`, когда UDP-ассоциацию нужно закрыть.
+fn service_udp_assoc(assoc: &mut ManagedUdpAssoc, sockets: &mut SocketSet) -> bool {
+    if let Some(ready_tx) = assoc.ready_tx.take() {
+        let _ = ready_tx.send(true);
+    }
+
+    if assoc.close_flag.load(Ordering::Relaxed) {
+        return true;
+    }
+
+    if assoc.last_seen.elapsed() > UDP_ASSOCIATE_IDLE_TIMEOUT {
+        info!("UDP ASSOCIATE port {} timed out", assoc.relay_port);
+        return true;
+    }
+
+    let socket = sockets.get_mut::<UdpSocket>(assoc.handle);
+    let mut tmp = vec![0u8; UDP_PAYLOAD_BUF];
+    while socket.can_recv() {
+        let (len, remote_meta) = match socket.recv_slice(&mut tmp) {
+            Ok(v) => v,
+            Err(_) => break,
+        };
+
+        if len == 0 {
+            continue;
+        }
+
+        let response = UdpRelayResponse {
+            relay_port: assoc.relay_port,
+            remote: remote_meta.endpoint,
+            payload: tmp[..len].to_vec(),
+        };
+
+        if assoc.outbound_tx.try_send(response).is_err() {
+            warn!(
+                "UDP relay response queue full for port {}",
+                assoc.relay_port
+            );
+            break;
+        }
+
+        assoc.last_seen = Instant::now();
+        debug!(
+            "UDP relay received {} bytes on port {}",
+            len, assoc.relay_port
+        );
+    }
+
+    false
+}
+
+fn socket_endpoint_to_socket_addr(endpoint: IpEndpoint) -> SocketAddr {
+    let ip = match endpoint.addr {
+        IpAddress::Ipv4(ip) => IpAddr::V4(Ipv4Addr::from(ip.0)),
+        IpAddress::Ipv6(ip) => IpAddr::V6(std::net::Ipv6Addr::from(ip.0)),
+    };
+    SocketAddr::new(ip, endpoint.port)
+}
+
+fn socket_addr_to_ip_endpoint(addr: SocketAddr) -> IpEndpoint {
+    match addr.ip() {
+        IpAddr::V4(ip) => {
+            let [a, b, c, d] = ip.octets();
+            IpEndpoint::new(IpAddress::v4(a, b, c, d), addr.port())
+        }
+        IpAddr::V6(ip) => {
+            IpEndpoint::new(IpAddress::Ipv6(Ipv6Address(ip.octets())), addr.port())
+        }
+    }
+}
+
+async fn handle_socks5(
+    stream: tokio::net::TcpStream,
+    cmd_tx: std::sync::mpsc::Sender<NewConn>,
+    udp_cmd_tx: std::sync::mpsc::Sender<UdpStackCommand>,
+    proxy_ip: IpAddr,
+) {
     let mut session = Socks5Session::new(stream);
 
-    let target_addr = match session.negotiate().await {
-        Ok(a) => a,
+    let req = match session.negotiate().await {
+        Ok(req) => req,
         Err(e) => {
             warn!("SOCKS5 negotiate: {}", e);
             let _ = session.send_reply(REP_GENERAL_FAILURE).await;
@@ -285,27 +613,61 @@ async fn handle_socks5(stream: tokio::net::TcpStream, cmd_tx: std::sync::mpsc::S
         }
     };
 
-    let target_ipv4 = match target_addr.ip() {
-        std::net::IpAddr::V4(ip) => ip,
-        std::net::IpAddr::V6(_) => {
-            warn!("Proxy: IPv6 targets not supported: {}", target_addr);
+    match req {
+        Socks5Command::Connect(target) => {
+            handle_connect(session, cmd_tx, udp_cmd_tx, target).await;  // ← +udp_cmd_tx
+        }
+        Socks5Command::UdpAssociate(_) => {
+            handle_udp_associate(session, udp_cmd_tx, proxy_ip).await;
+        }
+    }
+}
+
+async fn handle_connect(
+    mut session: Socks5Session,
+    cmd_tx: std::sync::mpsc::Sender<NewConn>,
+    udp_cmd_tx: std::sync::mpsc::Sender<UdpStackCommand>,
+    target_addr: TargetAddr,
+) {
+    let target: SocketAddr = match target_addr {
+        TargetAddr::Ip(a) => a,
+        TargetAddr::Domain(host, port) => {
+            match resolve_via_tunnel(&udp_cmd_tx, &host, port, /*want_v6=*/ false).await {
+                Ok(a) => a,
+                Err(e) => {
+                    warn!("TCP CONNECT DNS error {host}:{port}: {e}");
+                    let _ = session.send_reply(REP_HOST_UNREACHABLE).await;
+                    return;
+                }
+            }
+        }
+    };
+
+    let target_ipv4 = match target.ip() {
+        IpAddr::V4(ip) => ip,
+        IpAddr::V6(_) => {
+            warn!(
+                "Proxy: IPv6 targets not supported for TCP CONNECT: {}",
+                target
+            );
             let _ = session.send_reply(REP_HOST_UNREACHABLE).await;
             return;
         }
     };
 
     let [ta, tb, tc, td] = target_ipv4.octets();
-    let target = IpEndpoint::new(IpAddress::v4(ta, tb, tc, td), target_addr.port());
+    debug!("TCP CONNECT target {}.{}.{}.{}:{}", ta, tb, tc, td, target.port());
+    let smol_target = IpEndpoint::new(IpAddress::v4(ta, tb, tc, td), target.port());
     let src_port = alloc_src_port();
 
     let inbound: Arc<Mutex<VecDeque<Vec<u8>>>> = Arc::new(Mutex::new(VecDeque::new()));
     let close_flag = Arc::new(AtomicBool::new(false));
-    let (outbound_tx, mut outbound_rx) = tokio::sync::mpsc::channel::<Vec<u8>>(128);
+    let (outbound_tx, mut outbound_rx) = tokio::sync::mpsc::channel::<Vec<u8>>(1024);
     let (ready_tx, ready_rx) = std::sync::mpsc::sync_channel(1);
 
     if cmd_tx
         .send(NewConn {
-            target,
+            target: smol_target,
             src_port,
             inbound: Arc::clone(&inbound),
             outbound_tx,
@@ -318,7 +680,6 @@ async fn handle_socks5(stream: tokio::net::TcpStream, cmd_tx: std::sync::mpsc::S
         return;
     }
 
-    // Block a threadpool thread while the smoltcp TCP handshake completes
     let connected = tokio::task::spawn_blocking(move || {
         ready_rx.recv_timeout(CONNECT_TIMEOUT).unwrap_or(false)
     })
@@ -335,7 +696,6 @@ async fn handle_socks5(stream: tokio::net::TcpStream, cmd_tx: std::sync::mpsc::S
         return;
     }
 
-    // Bidirectional bridge: SOCKS5 TCP stream ↔ smoltcp per-socket queues
     let (mut socks_rd, mut socks_wr) = session.stream.into_split();
     let inbound_clone = Arc::clone(&inbound);
     let close_flag_rd = Arc::clone(&close_flag);
@@ -364,6 +724,230 @@ async fn handle_socks5(stream: tokio::net::TcpStream, cmd_tx: std::sync::mpsc::S
     tokio::select! {
         _ = read_half => {}
         _ = write_half => {}
+    }
+
+    close_flag.store(true, Ordering::Relaxed);
+}
+
+fn smol_ip_to_std(ip: IpAddress) -> IpAddr {
+    match ip {
+        IpAddress::Ipv4(v4) => IpAddr::V4(Ipv4Addr::from(v4.0)),
+        IpAddress::Ipv6(v6) => IpAddr::V6(std::net::Ipv6Addr::from(v6.0)),
+    }
+}
+
+/// Обработчик команды UDP ASSOCIATE по RFC 1928.
+///
+/// Схема работы:
+/// 1. Открываем реальный OS UDP-сокет (`relay_socket`) на адресе прокси.
+/// 2. Сообщаем клиенту адрес этого сокета в SOCKS5-ответе (RFC 1928 §6).
+/// 3. Регистрируем smoltcp UDP-сокет с тем же портом для приёма ответов через VPN.
+/// 4. Читаем SOCKS5 UDP Request (RFC 1928 §7) от клиента, извлекаем payload и цель.
+/// 5. Пересылаем payload через smoltcp в VPN-туннель.
+/// 6. Получаем UDP-ответы из VPN, оборачиваем в SOCKS5 UDP Response и отправляем клиенту.
+async fn handle_udp_associate(
+    mut session: Socks5Session,
+    udp_cmd_tx: std::sync::mpsc::Sender<UdpStackCommand>,
+    proxy_ip: IpAddr,
+) {
+    // Слушаем на том же IP, что и прокси (эфемерный порт).
+    let relay_socket = match tokio::net::UdpSocket::bind(SocketAddr::new(proxy_ip, 0)).await {
+        Ok(s) => Arc::new(s),
+        Err(e) => {
+            warn!("Failed to bind UDP relay socket: {}", e);
+            let _ = session.send_reply(REP_GENERAL_FAILURE).await;
+            return;
+        }
+    };
+
+    let relay_addr = match relay_socket.local_addr() {
+        Ok(addr) => addr,
+        Err(e) => {
+            warn!("Failed to read UDP relay local addr: {}", e);
+            let _ = session.send_reply(REP_GENERAL_FAILURE).await;
+            return;
+        }
+    };
+
+    let relay_port = relay_addr.port();
+    let close_flag = Arc::new(AtomicBool::new(false));
+    let (ready_tx, ready_rx) = std::sync::mpsc::sync_channel(1);
+    let (reply_tx, mut reply_rx) = mpsc::channel::<UdpRelayResponse>(256);
+
+    if udp_cmd_tx
+        .send(UdpStackCommand::CreateAssoc(NewUdpAssoc {
+            relay_port,
+            outbound_tx: reply_tx,
+            close_flag: Arc::clone(&close_flag),
+            ready_tx,
+        }))
+        .is_err()
+    {
+        let _ = session.send_reply(REP_GENERAL_FAILURE).await;
+        return;
+    }
+
+    // Ждём, пока smoltcp-поток зарегистрирует UDP-сокет.
+    let ready = tokio::task::spawn_blocking(move || {
+        ready_rx.recv_timeout(UDP_ASSOCIATE_TIMEOUT).unwrap_or(false)
+    })
+    .await
+    .unwrap_or(false);
+
+    if !ready {
+        let _ = session.send_reply(REP_HOST_UNREACHABLE).await;
+        return;
+    }
+
+    debug!("UDP ASSOCIATE: binding relay on {}, advertising port {}", relay_addr, relay_port);
+
+    // RFC 1928 §6: отправляем клиенту адрес UDP relay-сокета.
+    if session
+        .send_reply_with_addr(REP_SUCCESS, relay_addr)
+        .await
+        .is_err()
+    {
+        close_flag.store(true, Ordering::Relaxed);
+        return;
+    }
+
+    // IP клиента запомним при первом пакете (RFC 1928 разрешает 0.0.0.0:0 = «любой»).
+    let client_addr: Arc<Mutex<Option<SocketAddr>>> = Arc::new(Mutex::new(None));
+
+    let relay_socket_read = Arc::clone(&relay_socket);
+    let relay_socket_write = Arc::clone(&relay_socket);
+    let close_flag_rd = Arc::clone(&close_flag);
+    let client_addr_rd = Arc::clone(&client_addr);
+    let udp_tx = udp_cmd_tx.clone();
+
+    // Задача «клиент → VPN».
+    let read_task = tokio::spawn(async move {
+        let mut buf = vec![0u8; 65535];
+        let mut dns_cache: HashMap<(String, u16), SocketAddr> = HashMap::new();
+        loop {
+            if close_flag_rd.load(Ordering::Relaxed) {
+                break;
+            }
+
+            let (len, addr) = match relay_socket_read.recv_from(&mut buf).await {
+                Ok(v) => v,
+                Err(_) => break,
+            };
+
+            if len == 0 {
+                continue;
+            }
+
+            // Запоминаем адрес клиента при первом пакете; игнорируем пакеты от других.
+            {
+                let mut guard = client_addr_rd.lock().unwrap();
+                match &*guard {
+                    None => *guard = Some(addr),
+                    Some(known) if known != &addr => continue,
+                    Some(_) => {}
+                }
+            }
+
+            let request = match parse_udp_request(&buf[..len]) {
+                Ok(req) => req,
+                Err(e) => {
+                    warn!("SOCKS5 UDP parse error from {}: {}", addr, e);
+                    continue;
+                }
+            };
+
+            if request.frag != 0 {
+                // RFC 1928 §7: фрагментация опциональна; не поддерживаем.
+                warn!(
+                    "SOCKS5 UDP fragments not supported (frag={})",
+                    request.frag
+                );
+                continue;
+            }
+
+            let target_sock = match &request.target {
+                Socks5UdpTarget::Ip(a) => *a,
+                Socks5UdpTarget::Domain(host, port) => {
+                    let key = (host.clone(), *port);
+                    if let Some(a) = dns_cache.get(&key) {
+                        *a
+                    } else {
+                        match resolve_via_tunnel(&udp_tx, host, *port, /*want_v6=*/ false).await {
+                            Ok(a) => { dns_cache.insert(key, a); a }
+                            Err(e) => { warn!("SOCKS5 UDP DNS error {host}:{port}: {e}"); continue; }
+                        }
+                    }
+                }
+            };
+
+            if udp_tx
+                .send(UdpStackCommand::SendPacket(UdpPacketCommand {
+                    relay_port,
+                    target: socket_addr_to_ip_endpoint(target_sock),
+                    payload: request.data,
+                }))
+                .is_err()
+            {
+                break;
+            }
+        }
+
+        close_flag_rd.store(true, Ordering::Relaxed);
+    });
+
+    // Задача «VPN → клиент».
+    let close_flag_wr = Arc::clone(&close_flag);
+    let client_addr_wr = Arc::clone(&client_addr);
+    let write_task = tokio::spawn(async move {
+        while let Some(response) = reply_rx.recv().await {
+            if close_flag_wr.load(Ordering::Relaxed) {
+                break;
+            }
+
+            let client = {
+                let guard = client_addr_wr.lock().unwrap();
+                *guard
+            };
+            let client = match client {
+                Some(a) => a,
+                None => continue,
+            };
+
+            let packet = match build_udp_response(
+                &Socks5UdpTarget::Ip(socket_endpoint_to_socket_addr(response.remote)),
+                &response.payload,
+            ) {
+                Ok(pkt) => pkt,
+                Err(e) => {
+                    warn!("SOCKS5 UDP response build error: {}", e);
+                    continue;
+                }
+            };
+
+            if relay_socket_write.send_to(&packet, client).await.is_err() {
+                break;
+            }
+        }
+
+        close_flag_wr.store(true, Ordering::Relaxed);
+    });
+
+    // Слушаем TCP-канал управления: закрытие клиентом → завершаем UDP ASSOCIATE (RFC 1928 §6).
+    let mut ctrl_stream = session.stream;
+    let mut ctrl_buf = [0u8; 1];
+    let ctrl_task = tokio::spawn(async move {
+        loop {
+            match ctrl_stream.read(&mut ctrl_buf).await {
+                Ok(0) | Err(_) => break,
+                Ok(_) => {}
+            }
+        }
+    });
+
+    tokio::select! {
+        _ = read_task => {}
+        _ = write_task => {}
+        _ = ctrl_task => {}
     }
 
     close_flag.store(true, Ordering::Relaxed);

--- a/aivpn-client/src/proxy/mod.rs
+++ b/aivpn-client/src/proxy/mod.rs
@@ -49,6 +49,7 @@ pub struct ProxyConfig {
 
 pub struct ProxyHandle {
     pub rx_queue: Arc<Mutex<VecDeque<Vec<u8>>>>,
+    pub wake_tx: std::sync::mpsc::Sender<()>
 }
 
 struct ManagedConn {
@@ -124,6 +125,7 @@ pub async fn spawn_proxy(
 
     let (cmd_tx, cmd_rx) = std::sync::mpsc::channel::<NewConn>();
     let (udp_cmd_tx, udp_cmd_rx) = std::sync::mpsc::channel::<UdpStackCommand>();
+    let (wake_tx, wake_rx) = std::sync::mpsc::channel::<()>();
 
     let vpn_ip = config.vpn_ip;
     let gateway_ip = config.gateway_ip;
@@ -133,14 +135,15 @@ pub async fn spawn_proxy(
 
     std::thread::spawn(move || {
         run_stack(
-            rx_clone,
-            tx_clone,
-            tun_to_udp_tx,
-            cmd_rx,
-            udp_cmd_rx,
-            vpn_ip,
-            gateway_ip,
-            prefix_len,
+             rx_clone,
+             tx_clone,
+             tun_to_udp_tx,
+             cmd_rx,
+             udp_cmd_rx,
+             wake_rx,
+             vpn_ip,
+             gateway_ip,
+             prefix_len,
         );
     });
 
@@ -148,6 +151,7 @@ pub async fn spawn_proxy(
     info!("SOCKS5 proxy listening on {}", config.listen_addr);
 
     let proxy_ip = config.listen_addr.ip();
+    let wake_tx_accept = wake_tx.clone();
     tokio::spawn(async move {
         loop {
             match listener.accept().await {
@@ -155,7 +159,8 @@ pub async fn spawn_proxy(
                     debug!("Proxy: connection from {}", peer);
                     let tx = cmd_tx.clone();
                     let udp_tx = udp_cmd_tx.clone();
-                    tokio::spawn(handle_socks5(stream, tx, udp_tx, proxy_ip));
+                    let wtx = wake_tx_accept.clone();
+                    tokio::spawn(handle_socks5(stream, tx, udp_tx, wtx, proxy_ip));
                 }
                 Err(e) => {
                     error!("Proxy accept error: {}", e);
@@ -165,7 +170,7 @@ pub async fn spawn_proxy(
         }
     });
 
-    Ok(ProxyHandle { rx_queue })
+    Ok(ProxyHandle { rx_queue, wake_tx })
 }
 
 fn smoltcp_now() -> SmolInstant {
@@ -190,6 +195,7 @@ fn run_stack(
     tun_to_udp_tx: mpsc::Sender<Vec<u8>>,
     cmd_rx: std::sync::mpsc::Receiver<NewConn>,
     udp_cmd_rx: std::sync::mpsc::Receiver<UdpStackCommand>,
+    wake_rx: std::sync::mpsc::Receiver<()>,
     vpn_ip: Ipv4Addr,
     gateway_ip: Ipv4Addr,
     prefix_len: u8,
@@ -228,6 +234,7 @@ fn run_stack(
                     let tx_buf = TcpSocketBuffer::new(vec![0u8; TCP_BUF]);
                     let mut socket = TcpSocket::new(rx_buf, tx_buf);
                     socket.set_ack_delay(None);
+                    socket.set_nagle_enabled(false);
 
                     let mut cx = iface.context();
                     match socket.connect(&mut cx, nc.target, nc.src_port) {
@@ -391,13 +398,22 @@ fn run_stack(
                 sockets.remove(assoc.handle);
             }
         }
+        let timeout: std::time::Duration = iface
+            .poll_delay(smoltcp_now(), &sockets)
+            .map(Into::into)                                   // если From не найдётся:
+            .unwrap_or(std::time::Duration::from_millis(100)); // Duration::from_micros(d.total_micros())
 
-        std::thread::sleep(Duration::from_millis(1));
+        match wake_rx.recv_timeout(timeout) {
+            Ok(()) => { while wake_rx.try_recv().is_ok() {} }  // сдренировать пачку сигналов
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => return,
+        }
     }
 }
 
 async fn resolve_via_tunnel(
     cmd_tx: &std::sync::mpsc::Sender<UdpStackCommand>,
+    wake_tx: &std::sync::mpsc::Sender<()>,
     host: &str,
     port: u16,
     want_v6: bool,
@@ -423,6 +439,7 @@ async fn resolve_via_tunnel(
                 "stack thread gone",
             ));
         }
+        let _ = wake_tx.send(()); // разбудить стек: DNS-запрос
         let ip = tokio::task::spawn_blocking(move || {
             rx.recv_timeout(DNS_QUERY_TIMEOUT).ok().flatten()
         })
@@ -600,6 +617,7 @@ async fn handle_socks5(
     stream: tokio::net::TcpStream,
     cmd_tx: std::sync::mpsc::Sender<NewConn>,
     udp_cmd_tx: std::sync::mpsc::Sender<UdpStackCommand>,
+    wake_tx: std::sync::mpsc::Sender<()>,
     proxy_ip: IpAddr,
 ) {
     let mut session = Socks5Session::new(stream);
@@ -615,10 +633,10 @@ async fn handle_socks5(
 
     match req {
         Socks5Command::Connect(target) => {
-            handle_connect(session, cmd_tx, udp_cmd_tx, target).await;  // ← +udp_cmd_tx
+            handle_connect(session, cmd_tx, udp_cmd_tx, wake_tx, target).await;  // ← +udp_cmd_tx
         }
         Socks5Command::UdpAssociate(_) => {
-            handle_udp_associate(session, udp_cmd_tx, proxy_ip).await;
+            handle_udp_associate(session, udp_cmd_tx, wake_tx, proxy_ip).await;
         }
     }
 }
@@ -627,12 +645,13 @@ async fn handle_connect(
     mut session: Socks5Session,
     cmd_tx: std::sync::mpsc::Sender<NewConn>,
     udp_cmd_tx: std::sync::mpsc::Sender<UdpStackCommand>,
+    wake_tx: std::sync::mpsc::Sender<()>,
     target_addr: TargetAddr,
 ) {
     let target: SocketAddr = match target_addr {
         TargetAddr::Ip(a) => a,
         TargetAddr::Domain(host, port) => {
-            match resolve_via_tunnel(&udp_cmd_tx, &host, port, /*want_v6=*/ false).await {
+            match resolve_via_tunnel(&udp_cmd_tx, &wake_tx, &host, port, /*want_v6=*/ false).await {
                 Ok(a) => a,
                 Err(e) => {
                     warn!("TCP CONNECT DNS error {host}:{port}: {e}");
@@ -679,6 +698,7 @@ async fn handle_connect(
         let _ = session.send_reply(REP_GENERAL_FAILURE).await;
         return;
     }
+    let _ = wake_tx.send(()); // разбудить стек: новый CONNECT
 
     let connected = tokio::task::spawn_blocking(move || {
         ready_rx.recv_timeout(CONNECT_TIMEOUT).unwrap_or(false)
@@ -699,6 +719,7 @@ async fn handle_connect(
     let (mut socks_rd, mut socks_wr) = session.stream.into_split();
     let inbound_clone = Arc::clone(&inbound);
     let close_flag_rd = Arc::clone(&close_flag);
+    let wake_tx_rd = wake_tx.clone();
 
     let read_half = tokio::spawn(async move {
         let mut buf = vec![0u8; 8192];
@@ -707,6 +728,7 @@ async fn handle_connect(
                 Ok(0) | Err(_) => break,
                 Ok(n) => {
                     inbound_clone.lock().unwrap().push_back(buf[..n].to_vec());
+                    let _ = wake_tx_rd.send(()); // разбудить стек: данные от клиента
                 }
             }
         }
@@ -748,6 +770,7 @@ fn smol_ip_to_std(ip: IpAddress) -> IpAddr {
 async fn handle_udp_associate(
     mut session: Socks5Session,
     udp_cmd_tx: std::sync::mpsc::Sender<UdpStackCommand>,
+    wake_tx: std::sync::mpsc::Sender<()>,
     proxy_ip: IpAddr,
 ) {
     // Слушаем на том же IP, что и прокси (эфемерный порт).
@@ -786,6 +809,7 @@ async fn handle_udp_associate(
         let _ = session.send_reply(REP_GENERAL_FAILURE).await;
         return;
     }
+    let _ = wake_tx.send(()); // разбудить стек: новая UDP-ассоциация
 
     // Ждём, пока smoltcp-поток зарегистрирует UDP-сокет.
     let ready = tokio::task::spawn_blocking(move || {
@@ -819,6 +843,7 @@ async fn handle_udp_associate(
     let close_flag_rd = Arc::clone(&close_flag);
     let client_addr_rd = Arc::clone(&client_addr);
     let udp_tx = udp_cmd_tx.clone();
+    let wake_tx_rd = wake_tx.clone();
 
     // Задача «клиент → VPN».
     let read_task = tokio::spawn(async move {
@@ -872,7 +897,7 @@ async fn handle_udp_associate(
                     if let Some(a) = dns_cache.get(&key) {
                         *a
                     } else {
-                        match resolve_via_tunnel(&udp_tx, host, *port, /*want_v6=*/ false).await {
+                        match resolve_via_tunnel(&udp_tx, &wake_tx_rd, host, *port, /*want_v6=*/ false).await {
                             Ok(a) => { dns_cache.insert(key, a); a }
                             Err(e) => { warn!("SOCKS5 UDP DNS error {host}:{port}: {e}"); continue; }
                         }
@@ -890,6 +915,7 @@ async fn handle_udp_associate(
             {
                 break;
             }
+            let _ = wake_tx_rd.send(()); // разбудить стек: исходящий UDP-пакет
         }
 
         close_flag_rd.store(true, Ordering::Relaxed);

--- a/aivpn-client/src/proxy/socks5.rs
+++ b/aivpn-client/src/proxy/socks5.rs
@@ -6,6 +6,7 @@ const SOCKS5_VER: u8 = 5;
 const METHOD_NO_AUTH: u8 = 0;
 const METHOD_NO_ACCEPTABLE: u8 = 0xFF;
 const CMD_CONNECT: u8 = 1;
+const CMD_UDP_ASSOCIATE: u8 = 3;
 const ATYP_IPV4: u8 = 1;
 const ATYP_DOMAIN: u8 = 3;
 const ATYP_IPV6: u8 = 4;
@@ -14,6 +15,32 @@ pub const REP_SUCCESS: u8 = 0;
 pub const REP_GENERAL_FAILURE: u8 = 1;
 pub const REP_HOST_UNREACHABLE: u8 = 4;
 pub const REP_CMD_NOT_SUPPORTED: u8 = 7;
+pub const REP_ADDR_TYPE_NOT_SUPPORTED: u8 = 8;
+
+#[derive(Clone, Debug)]
+pub enum TargetAddr {
+    Ip(SocketAddr),
+    Domain(String, u16),
+}
+
+#[derive(Clone, Debug)]
+pub enum Socks5Command {
+    Connect(TargetAddr),          // было Connect(SocketAddr)
+    UdpAssociate(SocketAddr),
+}
+
+#[derive(Clone, Debug)]
+pub enum Socks5UdpTarget {
+    Ip(SocketAddr),
+    Domain(String, u16),
+}
+
+#[derive(Clone, Debug)]
+pub struct Socks5UdpPacket {
+    pub frag: u8,
+    pub target: Socks5UdpTarget,
+    pub data: Vec<u8>,
+}
 
 pub struct Socks5Session {
     pub stream: TcpStream,
@@ -24,8 +51,8 @@ impl Socks5Session {
         Self { stream }
     }
 
-    /// Perform SOCKS5 handshake and return the CONNECT target address.
-    pub async fn negotiate(&mut self) -> std::io::Result<SocketAddr> {
+    /// Perform SOCKS5 handshake and return the parsed command.
+    pub async fn negotiate(&mut self) -> std::io::Result<Socks5Command> {
         // Client greeting: VER NMETHODS METHODS...
         let mut header = [0u8; 2];
         self.stream.read_exact(&mut header).await?;
@@ -53,45 +80,59 @@ impl Socks5Session {
         // Request: VER CMD RSV ATYP ...
         let mut req = [0u8; 4];
         self.stream.read_exact(&mut req).await?;
-        if req[0] != SOCKS5_VER || req[1] != CMD_CONNECT {
-            self.send_reply(REP_CMD_NOT_SUPPORTED).await?;
+        if req[0] != SOCKS5_VER {
+            self.send_reply(REP_GENERAL_FAILURE).await?;
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
-                "only CONNECT is supported",
+                "invalid SOCKS version in request",
             ));
         }
 
-        let ip: std::net::IpAddr = match req[3] {
+        let cmd = req[1];
+        if cmd != CMD_CONNECT && cmd != CMD_UDP_ASSOCIATE {
+            self.send_reply(REP_CMD_NOT_SUPPORTED).await?;
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "only CONNECT and UDP ASSOCIATE are supported",
+            ));
+        }
+
+        let target = match req[3] {
             ATYP_IPV4 => {
                 let mut a = [0u8; 4];
                 self.stream.read_exact(&mut a).await?;
-                std::net::IpAddr::V4(std::net::Ipv4Addr::from(a))
+                let mut port_buf = [0u8; 2];
+                self.stream.read_exact(&mut port_buf).await?;
+                let port = u16::from_be_bytes(port_buf);
+                TargetAddr::Ip(SocketAddr::new(
+                    std::net::IpAddr::V4(std::net::Ipv4Addr::from(a)),
+                    port,
+                ))
             }
             ATYP_DOMAIN => {
                 let mut len_buf = [0u8; 1];
                 self.stream.read_exact(&mut len_buf).await?;
                 let mut name = vec![0u8; len_buf[0] as usize];
                 self.stream.read_exact(&mut name).await?;
-                let host = String::from_utf8_lossy(&name);
-                // Resolve hostname via system DNS on the async runtime
-                tokio::net::lookup_host(format!("{}:0", host))
-                    .await?
-                    .find(|a| a.is_ipv4())
-                    .map(|a| a.ip())
-                    .ok_or_else(|| {
-                        std::io::Error::new(
-                            std::io::ErrorKind::NotFound,
-                            format!("DNS: no IPv4 result for {host}"),
-                        )
-                    })?
+                let host = String::from_utf8_lossy(&name).into_owned();
+                let mut port_buf = [0u8; 2];
+                self.stream.read_exact(&mut port_buf).await?;
+                let port = u16::from_be_bytes(port_buf);
+                TargetAddr::Domain(host, port)          // ← резолв убрали, отдаём домен
             }
             ATYP_IPV6 => {
                 let mut a = [0u8; 16];
                 self.stream.read_exact(&mut a).await?;
-                std::net::IpAddr::V6(std::net::Ipv6Addr::from(a))
+                let mut port_buf = [0u8; 2];
+                self.stream.read_exact(&mut port_buf).await?;
+                let port = u16::from_be_bytes(port_buf);
+                TargetAddr::Ip(SocketAddr::new(
+                    std::net::IpAddr::V6(std::net::Ipv6Addr::from(a)),
+                    port,
+                ))
             }
             _ => {
-                self.send_reply(REP_GENERAL_FAILURE).await?;
+                self.send_reply(REP_ADDR_TYPE_NOT_SUPPORTED).await?;
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::InvalidData,
                     "unknown ATYP",
@@ -99,18 +140,179 @@ impl Socks5Session {
             }
         };
 
-        let mut port_buf = [0u8; 2];
-        self.stream.read_exact(&mut port_buf).await?;
-        let port = u16::from_be_bytes(port_buf);
+        Ok(match cmd {
+            CMD_CONNECT => Socks5Command::Connect(target),
+            CMD_UDP_ASSOCIATE => {
+                // Для UDP ASSOCIATE адрес в запросе — клиентский endpoint (обычно 0.0.0.0:0),
+                // handle_udp_associate его игнорирует. Домен сюда практически не приходит.
+                let sa = match target {
+                    TargetAddr::Ip(a) => a,
+                    TargetAddr::Domain(_, port) => SocketAddr::from(([0, 0, 0, 0], port)),
+                };
+                Socks5Command::UdpAssociate(sa)
+            }
+            _ => unreachable!(),
+        })
+    }
 
-        Ok(SocketAddr::new(ip, port))
+    /// Send SOCKS5 reply with explicit bind address.
+    pub async fn send_reply_with_addr(&mut self, rep: u8, bind: SocketAddr) -> std::io::Result<()> {
+        let mut out = Vec::with_capacity(22);
+        out.push(SOCKS5_VER);
+        out.push(rep);
+        out.push(0x00);
+        match bind.ip() {
+            std::net::IpAddr::V4(ip) => {
+                out.push(ATYP_IPV4);
+                out.extend_from_slice(&ip.octets());
+            }
+            std::net::IpAddr::V6(ip) => {
+                out.push(ATYP_IPV6);
+                out.extend_from_slice(&ip.octets());
+            }
+        }
+        out.extend_from_slice(&bind.port().to_be_bytes());
+        self.stream.write_all(&out).await
     }
 
     /// Send SOCKS5 reply. Bound address is reported as 0.0.0.0:0.
     pub async fn send_reply(&mut self, rep: u8) -> std::io::Result<()> {
-        // VER REP RSV ATYP BND.ADDR(4) BND.PORT(2)
-        self.stream
-            .write_all(&[SOCKS5_VER, rep, 0x00, ATYP_IPV4, 0, 0, 0, 0, 0, 0])
+        self.send_reply_with_addr(rep, SocketAddr::from(([0, 0, 0, 0], 0)))
             .await
+    }
+}
+
+pub fn parse_udp_request(packet: &[u8]) -> std::io::Result<Socks5UdpPacket> {
+    if packet.len() < 4 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "SOCKS5 UDP packet too short",
+        ));
+    }
+    if packet[0] != 0 || packet[1] != 0 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "invalid SOCKS5 UDP RSV",
+        ));
+    }
+
+    let frag = packet[2];
+    let atyp = packet[3];
+    let mut idx = 4usize;
+
+    let target = match atyp {
+        ATYP_IPV4 => {
+            if packet.len() < idx + 4 + 2 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "SOCKS5 UDP IPv4 header too short",
+                ));
+            }
+            let ip = std::net::Ipv4Addr::new(packet[idx], packet[idx + 1], packet[idx + 2], packet[idx + 3]);
+            idx += 4;
+            let port = u16::from_be_bytes([packet[idx], packet[idx + 1]]);
+            idx += 2;
+            Socks5UdpTarget::Ip(SocketAddr::new(std::net::IpAddr::V4(ip), port))
+        }
+        ATYP_IPV6 => {
+            if packet.len() < idx + 16 + 2 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "SOCKS5 UDP IPv6 header too short",
+                ));
+            }
+            let mut oct = [0u8; 16];
+            oct.copy_from_slice(&packet[idx..idx + 16]);
+            idx += 16;
+            let port = u16::from_be_bytes([packet[idx], packet[idx + 1]]);
+            idx += 2;
+            Socks5UdpTarget::Ip(SocketAddr::new(std::net::IpAddr::V6(std::net::Ipv6Addr::from(oct)), port))
+        }
+        ATYP_DOMAIN => {
+            if packet.len() < idx + 1 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "SOCKS5 UDP domain header too short",
+                ));
+            }
+            let len = packet[idx] as usize;
+            idx += 1;
+            if packet.len() < idx + len + 2 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "SOCKS5 UDP domain header too short",
+                ));
+            }
+            let host = String::from_utf8_lossy(&packet[idx..idx + len]).to_string();
+            idx += len;
+            let port = u16::from_be_bytes([packet[idx], packet[idx + 1]]);
+            idx += 2;
+            Socks5UdpTarget::Domain(host, port)
+        }
+        _ => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "unsupported SOCKS5 UDP ATYP",
+            ));
+        }
+    };
+
+    Ok(Socks5UdpPacket {
+        frag,
+        target,
+        data: packet[idx..].to_vec(),
+    })
+}
+
+pub fn build_udp_response(target: &Socks5UdpTarget, payload: &[u8]) -> std::io::Result<Vec<u8>> {
+    let mut out = Vec::with_capacity(payload.len() + 22);
+    out.extend_from_slice(&[0x00, 0x00, 0x00]); // RSV + FRAG=0
+    match target {
+        Socks5UdpTarget::Ip(addr) => match addr.ip() {
+            std::net::IpAddr::V4(ip) => {
+                out.push(ATYP_IPV4);
+                out.extend_from_slice(&ip.octets());
+            }
+            std::net::IpAddr::V6(ip) => {
+                out.push(ATYP_IPV6);
+                out.extend_from_slice(&ip.octets());
+            }
+        },
+        Socks5UdpTarget::Domain(host, port) => {
+            let host_bytes = host.as_bytes();
+            if host_bytes.len() > 255 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "domain name too long for SOCKS5 UDP",
+                ));
+            }
+            out.push(ATYP_DOMAIN);
+            out.push(host_bytes.len() as u8);
+            out.extend_from_slice(host_bytes);
+            out.extend_from_slice(&port.to_be_bytes());
+            out.extend_from_slice(payload);
+            return Ok(out);
+        }
+    }
+
+    let port = match target {
+        Socks5UdpTarget::Ip(addr) => addr.port(),
+        Socks5UdpTarget::Domain(_, port) => *port,
+    };
+    out.extend_from_slice(&port.to_be_bytes());
+    out.extend_from_slice(payload);
+    Ok(out)
+}
+
+pub async fn resolve_udp_target(target: &Socks5UdpTarget) -> std::io::Result<SocketAddr> {
+    match target {
+        Socks5UdpTarget::Ip(addr) => Ok(*addr),
+        Socks5UdpTarget::Domain(host, port) => tokio::net::lookup_host((host.as_str(), *port))
+            .await?
+            .find(|a| a.is_ipv4())
+            .ok_or_else(|| std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!("DNS: no IPv4 result for {host}:{port}"),
+            )),
     }
 }


### PR DESCRIPTION
## Что добавляет
SOCKS5-прокси (`--proxy-listen`) получает две возможности:
1. **Резолв DNS через туннель.** Имена из CONNECT (и из UDP-запросов) резолвятся
   smoltcp'шным `dns::Socket` через VPN-туннель, а не резолвером хостовой ОС. Запрос
   уходит в шифрованный туннель → нет утечки DNS на хост и работает для имён, которые
   локальный резолвер не отдаёт/подменяет (`socks5h`).
2. **UDP ASSOCIATE (RFC 1928).** Полноценный UDP-релей: relay-сокет на стороне прокси,
   smoltcp UDP-сокет в туннель, обёртка SOCKS5 UDP request/response, per-association
   DNS-кэш, пиннинг адреса клиента. Открывает QUIC/HTTP3 и прочий UDP через прокси.

### Детали реализации / на что смотреть при ревью
- Стек — userspace smoltcp. **MTU интерфейса = 1280, и это значимо:** smoltcp не делает
  TCP PMTUD (и `proto-ipv4-fragmentation` не включён — фрагменты не пересобирает),
  поэтому MTU задаётся консервативно заранее. При downstream через Cloudflare WARP
  (inner MTU 1280) бóльшие значения дают чёрную дыру: крупные входящие сегменты (обычно
  TLS Certificate не-Cloudflare хостов) дропаются и хендшейк виснет. 1280 это снимает.
- **Цикл стека — event-driven**, без busy-poll: поток спит на канале-будилке с таймаутом
  `iface.poll_delay()` и просыпается на входящих пакетах, новых CONNECT, исходящих данных
  и UDP/DNS-командах. `poll_delay` закрывает таймеры smoltcp, будилка — внешний I/O.
  `wake_tx` проброшен через `ProxyHandle` и клиента.
- `TcpSocket`: `set_nagle_enabled(false)` + `set_ack_delay(None)` для форвардинга.

### Известные ограничения / на будущее (в этом PR не решаются, отмечаю явно)
- **MTU захардкожен** в 1280 и предполагает downstream через Cloudflare WARP. Сервер с
  другим egress-MTU потребует другого значения — это должно быть опцией CLI/конфига (или
  выводиться из дескриптора сервера), а не константой. Комментарий
  `// совпадает с WAN_SAFE_TUN_MTU` вводит в заблуждение: это другое ограничение
  (downstream-путь, а не WAN-хоп).
- **IPv6 в proxy-режиме фактически не поддержан.** smoltcp-iface получает только
  IPv4-адрес и IPv4-маршрут по умолчанию, TCP DNS резолвит только A (`want_v6=false`), а
  `handle_connect` режет `ATYP_IPV6` / v6-резолв цели с `HOST_UNREACHABLE`. Поэтому
  `socks5h` работает (IPv4-only), а `socks5://` до dual-stack хоста может падать, когда
  клиент передаёт v6-литерал. `proto-ipv6` в `Cargo.toml` включён, но для роутинга не
  используется. 
- **Потолок скорости одного соединения.** В smoltcp нет TCP window scaling, поэтому окно
  приёма упирается в ~64 КБ независимо от `TCP_BUF`; одиночный поток ≈ 64 КБ / RTT. Для
  браузера (много соединений) ок, для одной большой загрузки — медленно.
- **DNS использует единственный захардкоженный резолвер** (`1.1.1.1`); Сокет работает только с одним сервером. Должно браться из конфига.